### PR TITLE
Add the event parameters to the event wrappers

### DIFF
--- a/src/components/marker.vue
+++ b/src/components/marker.vue
@@ -113,8 +113,8 @@ export default buildComponent({
 
   afterCreate(inst) {
     events.forEach((event)=> {
-      inst.addListener(event, ()=> {
-        this.$emit(event)
+      inst.addListener(event, (payload)=> {
+        this.$emit(event, payload)
       });
     })
     if (this.$clusterPromise) {


### PR DESCRIPTION
This PR adds the Marker's event params to wrapped event listeners.
The events like `drag`, `dragend`, ... have some arguments and they are required inside event listeners.