### PR TITLE
Forwards closeclick event from InfoWindow to Vue event.

### DIFF
--- a/src/components/infoWindow.vue
+++ b/src/components/infoWindow.vue
@@ -73,7 +73,11 @@ export default buildComponent({
     },
   },
 
-  afterCreate() {
+  afterCreate(inst) {
+    inst.addEventListener('closeclick', () => {
+      this.$emit('closeclick')
+    });
+
     this._openInfoWindow()
     this.$watch('opened', () => {
       this._openInfoWindow()


### PR DESCRIPTION
I happened to notice that when using the close button on an InfoWindow _or_ pressing escape, the `closeclick` event was not being emitted. This is because the `closeclick` event emitted by Google was not being listened to. This PR resolves that.