### PR TITLE
Use render instead of repaint

### DIFF
--- a/src/components/cluster.vue
+++ b/src/components/cluster.vue
@@ -98,7 +98,7 @@ export default buildComponent({
   },
   updated() {
     if (this.$clusterObject) {
-      this.$clusterObject.repaint()
+      this.$clusterObject.render()
     }
   },
   beforeUnmount() {


### PR DESCRIPTION
After getting the error `this.$clusterObject.repaint is not a function`, I have search for a solution and found this. Replacing the function call render() instead of repaint() solves this issue.