### PR TITLE
Fix v-bind ordering to supress warning

### DIFF
--- a/src/components/autocomplete.vue
+++ b/src/components/autocomplete.vue
@@ -1,5 +1,5 @@
 <template>
-  <input ref="input" v-bind="$attrs" v-on="$attrs" />
+  <input v-bind="$attrs" ref="input" v-on="$attrs" />
 </template>
 
 <script>


### PR DESCRIPTION
A warning is reported from Vue 3 compat build regarding the usage of `v-bind="$attrs"`, as attribute merging is now affected by the attribute ordering: https://v3-migration.vuejs.org/breaking-changes/v-bind.html

<img width="696" alt="image" src="https://user-images.githubusercontent.com/4430606/229169495-5c84293d-3345-4a41-885f-e466600a1571.png">

Moving `v-bind="$attrs"` to first place, supresses this warning and doesn't affect the component's behavior.