### PR TITLE
Fix autocomplete attributes

### DIFF
--- a/src/components/autocomplete.vue
+++ b/src/components/autocomplete.vue
@@ -1,5 +1,5 @@
 <template>
-  <input ref="input" v-bind="$attrs" v-on="$attrs" />
+  <input ref="input" v-bind="$attrs" />
 </template>
 
 <script>

--- a/src/components/autocomplete.vue
+++ b/src/components/autocomplete.vue
@@ -1,5 +1,5 @@
 <template>
-  <input ref="input" v-bind="$attrs" />
+  <input v-bind="$attrs" ref="input" />
 </template>
 
 <script>


### PR DESCRIPTION
- remove extra v-on on autocomplete input
- fix the extra warning on vue-compat
![image](https://github.com/fawmi/vue-google-maps/assets/16442858/29173914-f96a-4a54-a9a5-e63f6e198b67)
